### PR TITLE
 Add token refresh/migrate functions

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,13 @@
 %%-*- mode: erlang -*-
+{erl_opts, [
+            debug_info,
+            {parse_transform, lager_transform}
+           ]}.
+
 
 {deps, [ {calendar_ext, {git, "https://bitbucket.org/a12n/calendar_ext.git", {ref, "2ff0eea"}}},
-         {jsx, "2.8.0"} ]}.
+         {jsx, "2.8.0"},
+         lager]}.
 
 {profiles, [{test, [{deps, [ {meck, "0.8.13"},
                              {sync, {git, "https://github.com/rustyio/sync", {ref, "9c78e7b"}}} ]}]}]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,5 +1,14 @@
+{"1.1.0",
 [{<<"calendar_ext">>,
   {git,"https://bitbucket.org/a12n/calendar_ext.git",
        {ref,"2ff0eea2bf9994668626cad7a9aa078917ce4664"}},
   0},
- {<<"jsx">>,{pkg,<<"jsx">>,<<"2.8.0">>},0}].
+ {<<"goldrush">>,{pkg,<<"goldrush">>,<<"0.1.9">>},1},
+ {<<"jsx">>,{pkg,<<"jsx">>,<<"2.8.0">>},0},
+ {<<"lager">>,{pkg,<<"lager">>,<<"3.6.9">>},0}]}.
+[
+{pkg_hash,[
+ {<<"goldrush">>, <<"F06E5D5F1277DA5C413E84D5A2924174182FB108DABB39D5EC548B27424CD106">>},
+ {<<"jsx">>, <<"749BEC6D205C694AE1786D62CEA6CC45A390437E24835FD16D12D74F07097727">>},
+ {<<"lager">>, <<"387BCD836DC0C8AD9C6D90A0E0CE5B29676847950CBC527BCCC194A02028DE8E">>}]}
+].

--- a/src/strava_auth.erl
+++ b/src/strava_auth.erl
@@ -12,7 +12,7 @@
 
 %% API
 -export([authorize_url/2, authorize_url/3, authorize_url/5,
-         deauthorize/1, token/3, token/4, migrate/3]).
+         deauthorize/1, token/3, token/4, migrate/3, refresh/3]).
 
 %%%===================================================================
 %%% Types
@@ -20,13 +20,7 @@
 
 -type approval_prompt() :: auto | force.
 -type scope() :: public | write | view_private | view_private_write.
--type token() :: binary() | v2_token().
--type v2_token() :: #{version := v2,
-                      refresh := binary(),
-                      access := binary(),
-                      expires_at := pos_integer(),
-                      expires_in := pos_integer()
-                     }.
+-type token() :: binary(). %% backwards compatible used in API at large
 
 %%%===================================================================
 %%% API
@@ -78,12 +72,13 @@ authorize_url(ClientId, RedirectUri, Scope, ApprovalPrompt, State) ->
 %% data. This will invalidate all access token, including the `Token'.
 %% @end
 %%--------------------------------------------------------------------
--spec deauthorize(token()) -> ok | strava:error().
+-spec deauthorize(strava_token:token()) -> ok | strava:error().
 
 deauthorize(Token) ->
+    RefreshToken = strava_token:get_refresh_token(Token),
     case strava_http:request(
            _Method = post,
-           _Headers = [{<<"Authorization">>, [<<"Bearer ">>, Token]}],
+           _Headers = [{<<"Authorization">>, [<<"Bearer ">>, RefreshToken]}],
            _URL = url(<<"deauthorize">>),
            _Query = #{},
            _ContentType = <<>>,
@@ -106,7 +101,7 @@ deauthorize(Token) ->
 %% @end
 %%--------------------------------------------------------------------
 -spec token(integer(), binary(), binary()) ->
-                   {ok, token(), strava_athlete:t()} | strava:error().
+                   {ok, strava_token:token(), strava_athlete:t()} | strava:error().
 
 token(ClientId, ClientSecret, Code) ->
     token(ClientId, ClientSecret, Code, _Migrate=false).
@@ -125,7 +120,7 @@ token(ClientId, ClientSecret, Code) ->
 %% @end
 %%--------------------------------------------------------------------
 -spec token(integer(), binary(), binary(), boolean()) ->
-                   {ok, token(), strava_athlete:t()} | strava:error().
+                   {ok, strava_token:token(), strava_athlete:t()} | strava:error().
 
 token(ClientId, ClientSecret, Code, Migrate) ->
     case strava_http:request(
@@ -142,10 +137,10 @@ token(ClientId, ClientSecret, Code, Migrate) ->
     of
         {ok, ResBody} ->
             Decoded = strava_json:decode(ResBody),
-            Token = token_from_response(Decoded),
+            Token = strava_token:token_from_response(Decoded),
             #{<<"athlete">> := Athlete0} = Decoded,
             Athlete = strava_repr:to_athlete(Athlete0),
-            case (Migrate andalso v1_token(Token)) of
+            case (Migrate andalso strava_token:is_forever_token(Token)) of
                 false ->
                     {ok, Token, Athlete};
                 true ->
@@ -157,17 +152,28 @@ token(ClientId, ClientSecret, Code, Migrate) ->
 
 %%--------------------------------------------------------------------
 %% @doc
-%% Completing the token exchange. If the user accepts the request to
-%% share access to their Strava data, Strava will redirect back to
-%% redirect_uri with the authorization code. The application must now
-%% exchange the temporary authorization code for an access token,
-%% using its client ID and client secret.
+%% With the new strava short-lived access tokens, migrate a user's
+%% forever token to a refresh-token/access-token pair.
 %% @end
 %%--------------------------------------------------------------------
--spec migrate(integer(), binary(), binary()) ->
-                   {ok, token()} | strava:error().
+-spec migrate(integer(), binary(), strava_token:token()) ->
+                     %% actually we only want to accept forever
+                     %% tokens, dialyzer!
+                   {ok, strava_token:refresh_token()} | strava:error().
 
 migrate(ClientId, ClientSecret, ForeverToken) ->
+    refresh(ClientId, ClientSecret, ForeverToken).
+
+%%--------------------------------------------------------------------
+%% @doc
+%% Refresh an expired access token
+%% @end
+%%--------------------------------------------------------------------
+-spec refresh(integer(), binary(), strava_token:token()) ->
+                   {ok, strava_token:refresh_token()} | strava:error().
+
+refresh(ClientId, ClientSecret, Token) ->
+    RefreshToken = strava_token:get_refresh_token(Token),
     case strava_http:request(
            _Method = post,
            _Headers = [],
@@ -176,14 +182,14 @@ migrate(ClientId, ClientSecret, ForeverToken) ->
            _ContentType = <<"application/x-www-form-urlencoded">>,
            _Body = strava_http:qs(#{client_id     => ClientId,
                                     client_secret => ClientSecret,
-                                    refresh_token => ForeverToken,
+                                    refresh_token => RefreshToken,
                                     grant_type    => <<"refresh_token">>})
           )
     of
         {ok, ResBody} ->
             Decoded = strava_json:decode(ResBody),
-            Token = token_from_response(Decoded),
-            {ok, Token};
+            NewToken = strava_token:refresh_token_from_response(Decoded),
+            {ok, NewToken};
         {error, ResBody} ->
             strava_repr:to_error(strava_json:decode(ResBody))
     end.
@@ -241,43 +247,17 @@ url(Suffix, Query) ->
     [<<"https://www.strava.com/oauth/">>, Suffix,
      strava_http:qs(Query, <<"?">>)].
 
-%% decide on the token version type, returning backwards compatible
-%% plain binary for v1, or a map for refresh etc for v2
--spec token_from_response(map()) -> token().
-token_from_response(TokenMap) ->
-    Token =
-        case maps:is_key(<<"refresh_token">>, TokenMap) of
-            true ->
-                %% This is a 'v2' map
-            #{<<"refresh_token">> := RefreshToken,
-              <<"access_token">> := AccessToken,
-              <<"expires_in">> := ExpiresIn,
-              <<"expires_at">> := ExpiresAt} = TokenMap,
-            #{version => v2,
-              refresh => RefreshToken,
-              access => AccessToken,
-              expires_at => ExpiresAt,
-              expires_in => ExpiresIn};
-            false ->
-                %% this is an old forever token
-                #{<<"access_token">> := ForeverToken} = TokenMap,
-                ForeverToken
-        end,
-    Token.
-
--spec v1_token(token()) -> boolean().
-v1_token(Token) when is_binary(Token) ->
-    true;
-v1_token(Token) when is_map(Token) ->
-    false.
 
 %%--------------------------------------------------------------------
 %% @doc
 %% Migrate a newly acquired `ForeverToken' for `Athlete' to a v2
-%% refresh token. If migration fails, an error is logegd and the
+%% refresh token. If migration fails, an error is logged and the
 %% forever token returned
 %% @end
 %%--------------------------------------------------------------------
+-spec migrate_new(pos_integer(), binary(), strava_token:token(),
+                  strava_athlete:t()) ->
+                         {ok, strava_token:token(), strava_athlete:t()}.
 migrate_new(ClientId, ClientSecret, ForeverToken, Athlete) ->
     case migrate(ClientId, ClientSecret, ForeverToken) of
         {ok, Token} ->

--- a/src/strava_auth.erl
+++ b/src/strava_auth.erl
@@ -259,6 +259,7 @@ url(Suffix, Query) ->
                   strava_athlete:t()) ->
                          {ok, strava_token:token(), strava_athlete:t()}.
 migrate_new(ClientId, ClientSecret, ForeverToken, Athlete) ->
+    lager:info("auto-migrating athlete"),
     case migrate(ClientId, ClientSecret, ForeverToken) of
         {ok, Token} ->
             {ok, Token, Athlete};

--- a/src/strava_token.erl
+++ b/src/strava_token.erl
@@ -84,7 +84,9 @@ get_refresh_token(#{version := v2, refresh_token := Token}) ->
 -spec needs_refresh(token(), StoreSecs::pos_integer()) ->
                            boolean().
 needs_refresh(#{version := 1}, _) ->
-    false;
+    %% NOTE: refresh == migrate for forever token, and we should
+    %% migrate all remaining forever tokens
+    true;
 needs_refresh(#{version := 2, expires_in := TTLSecs}, StoredSecs) ->
     %% 3600 == an hour in seconds
     ExpireSecs = TTLSecs + StoredSecs,

--- a/src/strava_token.erl
+++ b/src/strava_token.erl
@@ -1,0 +1,78 @@
+%%%-------------------------------------------------------------------
+%%% @doc
+%%% Types and functions related to Strava authentication tokens.
+%%% @reference http://strava.github.io/api/v3/oauth/
+%%% @end
+%%% For copyright notice see LICENSE.
+%%%-------------------------------------------------------------------
+-module(strava_token).
+
+-export([token_from_response/1,
+         refresh_token_from_response/1,
+         is_forever_token/1,
+         get_refresh_token/1]).
+
+-opaque token() ::  forever_token() | refresh_token().
+-opaque forever_token() :: v1_token() | legacy_token().
+-opaque refresh_token() :: v2_token().
+-type legacy_token() :: binary().
+-type v1_token() :: #{version := v1,
+                      forever_token := binary()
+                     }.
+
+-type v2_token() :: #{version := v2,
+                      refresh := binary(),
+                      access := binary(),
+                      expires_at := pos_integer(),
+                      expires_in := pos_integer()
+                     }.
+
+-export_type([token/0, forever_token/0, refresh_token/0]).
+
+
+-spec refresh_token_from_response(map()) -> refresh_token().
+refresh_token_from_response(TokenMap) ->
+    %% v2 or crash
+    #{<<"refresh_token">> := RefreshToken,
+      <<"access_token">> := AccessToken,
+      <<"expires_in">> := ExpiresIn,
+      <<"expires_at">> := ExpiresAt} = TokenMap,
+    #{version => v2,
+      refresh => RefreshToken,
+      access => AccessToken,
+      expires_at => ExpiresAt,
+      expires_in => ExpiresIn}.
+
+%% decide on the token version type, returning v1 forever token, or a
+%% map for refresh etc for v2
+-spec token_from_response(map()) -> token().
+token_from_response(TokenMap) ->
+    Token =
+        case maps:is_key(<<"refresh_token">>, TokenMap) of
+            true ->
+                %% This is a 'v2' map
+                refresh_token_from_response(TokenMap);
+            false ->
+                %% this is an old forever token
+                #{<<"access_token">> := ForeverToken} = TokenMap,
+                #{version => v1,
+                  forever_token => ForeverToken}
+        end,
+    Token.
+
+-spec is_forever_token(token()) -> boolean().
+is_forever_token(Token) when is_binary(Token) ->
+    true;
+is_forever_token(#{version := v1})  ->
+    true;
+is_forever_token(_) ->
+    false.
+
+-spec get_refresh_token(token()) -> binary().
+get_refresh_token(Token) when is_binary(Token) ->
+    %% assume a legacy forever token
+    Token;
+get_refresh_token(#{version := v1, forever_token := Token}) ->
+    Token;
+get_refresh_token(#{version := v2, refresh_token := Token}) ->
+    Token.


### PR DESCRIPTION
This still leaves some burden on the deployer/user to work with backwards compatible/old tokens